### PR TITLE
Safe type array useage & stopped potential memory leak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ local.properties
 *.settings/
 bin/
 gen/
+*.idea
+*.iml

--- a/library/src/com/readystatesoftware/systembartint/SystemBarTintManager.java
+++ b/library/src/com/readystatesoftware/systembartint/SystemBarTintManager.java
@@ -74,8 +74,12 @@ public class SystemBarTintManager {
 			int[] attrs = {android.R.attr.windowTranslucentStatus,
 					android.R.attr.windowTranslucentNavigation};
 			TypedArray a = activity.obtainStyledAttributes(attrs);
+            try {
 			mStatusBarAvailable = a.getBoolean(0, false);
 			mNavBarAvailable = a.getBoolean(1, false);
+            } finally {
+                a.recycle();
+            }
 
 			// check window flags
 			WindowManager.LayoutParams winParams = win.getAttributes();

--- a/library/src/com/readystatesoftware/systembartint/SystemBarTintManager.java
+++ b/library/src/com/readystatesoftware/systembartint/SystemBarTintManager.java
@@ -48,7 +48,7 @@ public class SystemBarTintManager {
 	 */
 	public static final int DEFAULT_TINT_COLOR = Color.parseColor("#99000000");
 
-	private SystemBarConfig mConfig;
+	private final SystemBarConfig mConfig;
 	private boolean mStatusBarAvailable;
 	private boolean mNavBarAvailable;
 	private boolean mStatusBarTintEnabled;
@@ -306,15 +306,15 @@ public class SystemBarTintManager {
 		private static final String NAV_BAR_HEIGHT_LANDSCAPE_RES_NAME = "navigation_bar_height_landscape";
 		private static final String NAV_BAR_WIDTH_RES_NAME = "navigation_bar_width";
 
-		private boolean mTranslucentStatusBar;
-		private boolean mTranslucentNavBar;
-		private int mStatusBarHeight;
-		private int mActionBarHeight;
-		private boolean mHasNavigationBar;
-		private int mNavigationBarHeight;
-		private int mNavigationBarWidth;
-		private boolean mInPortrait;
-		private float mSmallestWidthDp;
+		private final boolean mTranslucentStatusBar;
+		private final boolean mTranslucentNavBar;
+		private final int mStatusBarHeight;
+		private final int mActionBarHeight;
+		private final boolean mHasNavigationBar;
+		private final int mNavigationBarHeight;
+		private final int mNavigationBarWidth;
+		private final boolean mInPortrait;
+		private final float mSmallestWidthDp;
 
 		private SystemBarConfig(Activity activity, boolean translucentStatusBar, boolean traslucentNavBar) {
 			Resources res = activity.getResources();

--- a/library/src/com/readystatesoftware/systembartint/SystemBarTintManager.java
+++ b/library/src/com/readystatesoftware/systembartint/SystemBarTintManager.java
@@ -74,12 +74,12 @@ public class SystemBarTintManager {
 			int[] attrs = {android.R.attr.windowTranslucentStatus,
 					android.R.attr.windowTranslucentNavigation};
 			TypedArray a = activity.obtainStyledAttributes(attrs);
-            try {
-			    mStatusBarAvailable = a.getBoolean(0, false);
-			    mNavBarAvailable = a.getBoolean(1, false);
-            } finally {
-                a.recycle();
-            }
+                       try {
+                           mStatusBarAvailable = a.getBoolean(0, false);
+                           mNavBarAvailable = a.getBoolean(1, false);
+                       } finally {
+                           a.recycle();
+                       }
 
 			// check window flags
 			WindowManager.LayoutParams winParams = win.getAttributes();

--- a/library/src/com/readystatesoftware/systembartint/SystemBarTintManager.java
+++ b/library/src/com/readystatesoftware/systembartint/SystemBarTintManager.java
@@ -75,8 +75,8 @@ public class SystemBarTintManager {
 					android.R.attr.windowTranslucentNavigation};
 			TypedArray a = activity.obtainStyledAttributes(attrs);
             try {
-			mStatusBarAvailable = a.getBoolean(0, false);
-			mNavBarAvailable = a.getBoolean(1, false);
+			    mStatusBarAvailable = a.getBoolean(0, false);
+			    mNavBarAvailable = a.getBoolean(1, false);
             } finally {
                 a.recycle();
             }

--- a/library/src/com/readystatesoftware/systembartint/SystemBarTintManager.java
+++ b/library/src/com/readystatesoftware/systembartint/SystemBarTintManager.java
@@ -299,7 +299,7 @@ public class SystemBarTintManager {
 	 * device configuration.
 	 *
 	 */
-	public class SystemBarConfig {
+	public static class SystemBarConfig {
 
 		private static final String STATUS_BAR_HEIGHT_RES_NAME = "status_bar_height";
 		private static final String NAV_BAR_HEIGHT_RES_NAME = "navigation_bar_height";

--- a/library/src/com/readystatesoftware/systembartint/SystemBarTintManager.java
+++ b/library/src/com/readystatesoftware/systembartint/SystemBarTintManager.java
@@ -74,12 +74,12 @@ public class SystemBarTintManager {
 			int[] attrs = {android.R.attr.windowTranslucentStatus,
 					android.R.attr.windowTranslucentNavigation};
 			TypedArray a = activity.obtainStyledAttributes(attrs);
-                       try {
-                           mStatusBarAvailable = a.getBoolean(0, false);
-                           mNavBarAvailable = a.getBoolean(1, false);
-                       } finally {
-                           a.recycle();
-                       }
+           try {
+               mStatusBarAvailable = a.getBoolean(0, false);
+               mNavBarAvailable = a.getBoolean(1, false);
+           } finally {
+               a.recycle();
+           }
 
 			// check window flags
 			WindowManager.LayoutParams winParams = win.getAttributes();


### PR DESCRIPTION
Just some small optimisations as I was looking through the project.

Recycled the requested type array.

Made the inner class static, this stops it holding a reference to the `SystemBarTintManager` ; which holds a reference to the `Context`. In the case that someone uses the `getSystemBarConfig` and holds onto the `SystemBarConfig`.

Highlighted immutable fields.
