### PR TITLE
Fixed bug where getActionBarHeight would throw a ResourcesNotFoundException

### DIFF
--- a/library/src/com/readystatesoftware/systembartint/SystemBarTintManager.java
+++ b/library/src/com/readystatesoftware/systembartint/SystemBarTintManager.java
@@ -390,7 +390,7 @@ public class SystemBarTintManager {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
                 TypedValue tv = new TypedValue();
                 context.getTheme().resolveAttribute(android.R.attr.actionBarSize, tv, true);
-                result = context.getResources().getDimensionPixelSize(tv.resourceId);
+                result = TypedValue.complexToDimensionPixelSize(tv.data, context.getResources().getDisplayMetrics());
             }
             return result;
         }


### PR DESCRIPTION
Fixed bug where `getActionBarHeight` would throw a `ResourcesNotFoundException` if custom value was set for `android:actionBarSize` in the theme.

To replicate bug, in the current app's theme set: 

```
<item name="android:actionBarSize">56dp</item>
```

Then constructing a new SystemBarTintManager will throw a `Resources$NotFoundException`

It looks as is this bug may be related to issues seen by @nubela in issue #8

Cheers, Rich
