### PR TITLE
Added check for SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN

### DIFF
--- a/library/src/com/readystatesoftware/systembartint/SystemBarTintManager.java
+++ b/library/src/com/readystatesoftware/systembartint/SystemBarTintManager.java
@@ -100,6 +100,13 @@ public class SystemBarTintManager {
             } finally {
                 a.recycle();
             }
+            
+            // check system ui flags
+			int uiVis = activity.getWindow().getDecorView().getSystemUiVisibility();
+			int viewBits = View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN;
+			if ((uiVis & viewBits) != 0) {
+				mStatusBarAvailable = true;
+			}
 
             // check window flags
             WindowManager.LayoutParams winParams = win.getAttributes();


### PR DESCRIPTION
Currently SystemBarTiny doesn't work when only using View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN.

On Android L, the status bar can be made fully transparent using View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN. This enables SystemBarTint to be used in this mode.
